### PR TITLE
remove duplicate python-dateutil

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,3 @@ six==1.3.0
 urllib3==1.7.1
 wsgiref==0.1.2
 uritemplate
-python-dateutil==1.5


### PR DESCRIPTION
I was getting yelled at when trying to get Sheer up and running:

```
Double requirement given: python-dateutil==1.5 (from -r requirements.txt (line 19)) (already in python-dateutil==2.1 (from -r requirements.txt (line 13)), name='python-dateutil')
```
