### PR TITLE
Straighten up api

### DIFF
--- a/sheer/sheer_api.py
+++ b/sheer/sheer_api.py
@@ -81,12 +81,19 @@ class SheerAPI(object):
                     self.args['q'] = self.add_2q('', item)
                 else:
                     self.args['q'] += self.add_2q(' AND ', item)
-            elif item[0] == 'from':
+            elif item[0] == 'from' or item[0] == 'offset':
                 self.args['from_'] = item[1]
+            elif item[0] == 'limit':
+                self.args['size'] = item[1]
+            elif item[0] == 'page_no':
+                self.page_no = abs(int(item[1])) - 1
             elif item[0] == 'fields':
                 self.fields = item[1].split(',')
             else:
                 self.args[item[0]] = item[1]
+        else:
+            if hasattr(self, 'page_no'):
+                self.args['from_'] = self.page_no * int(self.args.get('size', 10))
 
         pattern = r'^/(?P<api_version>v\d+)/(?P<content_type>' + '|'.join(self.allowed_content) + ')/?'
         match = re.match(pattern, environ['PATH_INFO'])


### PR DESCRIPTION
`fields` parameter is a comma separated list, the API will return only those that are present in the returned object. An additional `_id` field is added too.

`limit` or `size` (default 10 when `page_no` is present) is an int defining number of items to return

`from` or `offset` an int defining how many items to skip before returning the results, starts with 1

`page_no` an int defining page to start returning results from, 1 actually means "return w/o skipping anything"
