### PR TITLE
Expose current date in templates

### DIFF
--- a/sheer/wsgi.py
+++ b/sheer/wsgi.py
@@ -3,6 +3,7 @@ import os.path
 import re
 import functools
 import markdown
+import datetime
 
 import flask
 import elasticsearch
@@ -97,6 +98,11 @@ def app_with_config(config):
                                         flask.request.path,
                                         append='_queries')
         context = {'queries': QueryFinder(search_path)}
+        return context
+
+    @app.context_processor
+    def current_date():
+        context = {'current_date': datetime.datetime.now()}
         return context
 
     @app.template_filter(name='date')


### PR DESCRIPTION
For a number of reasons, the FEWDs need access to elements of the current date in the template files (e.g. knowing the current year for the date filter dropdown)

You should now be able to access it with {{ current_date }}, and you can use the existing date filter.

Current year would be {{ current_date | date("%Y") }}
