### PR TITLE
Removed the specific version of itsdangerous in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Werkzeug==0.9.1
 autopep8==0.9.2
 distribute==0.6.34
 elasticsearch==0.4.3
-itsdangerous==0.23
+itsdangerous
 nose==1.3.0
 pep8==1.4.6
 python-dateutil==2.1


### PR DESCRIPTION
Removed the specific version of itsdangerous because there was an issue on RHEL systems (not sure if also for debian-based systems) where it would not download from pypi.  It seems that removing the version here fixes the problem.
