### PR TITLE
remove double "results" in json API

### DIFF
--- a/sheer/apis/apiv1.py
+++ b/sheer/apis/apiv1.py
@@ -26,7 +26,7 @@ def add_to_sheer(app):
             query_finder = default_query_finder()
             query = getattr(query_finder, name)
             request = flask.request
-            return {'results':query.search_with_url_arguments()}
+            return query.search_with_url_arguments()
 
     api.add_resource(QueryResource, '/api/v1/q/<name>.json')
 


### PR DESCRIPTION
Currently, the json API returns things in the form {'results': {'results': the actual results}}

That's silly. This fixes that.
