### PR TITLE
Proper defaults for date ranges that don't specify day

### DIFF
--- a/sheer/filters.py
+++ b/sheer/filters.py
@@ -1,5 +1,6 @@
 import flask
 import re
+import calendar
 from dateutil.parser import parse
 
 def filter_dsl_from_multidict(multidict):
@@ -36,18 +37,26 @@ def filter_dsl_from_multidict(multidict):
             # If there are multiples of the same date filter, this will take the first
             value = multidict.getlist(key)[0]
             range_clause["range"][field][operator] = value
-
+        
         # Validate date range input
         
         # First check if both date_lte and date_gte are present
         # If the 'start' date is after the 'end' date, swap them
-        if 'date' in range_clause['range'] and all(x in range_clause['range']['date'] for x in ('lte', 'gte')):
-            if parse(range_clause['range']['date']['gte']) > \
-            parse(range_clause['range']['date']['lte']):
+        if 'date' in range_clause['range']:
+            if all(x in range_clause['range']['date'] for x in ('lte', 'gte')) and \
+             parse(range_clause['range']['date']['gte']) > parse(range_clause['range']['date']['lte']):
                 range_clause['range']['date']['gte'], range_clause['range']['date']['lte'] = \
                 range_clause['range']['date']['lte'], range_clause['range']['date']['gte']
+            # If either date matches the YYYY-M[M] format, append the appropriate day
+            if 'lte' in range_clause['range']['date'] and \
+            re.compile("^[0-9]{4}-[0-9]{1,2}$").match(range_clause['range']['date']['lte']):
+                year, month = range_clause['range']['date']['lte'].split('-')
+                last_day_of_month = calendar.monthrange(int(year), int(month))[1]
+                range_clause['range']['date']['lte'] += "-{}".format(last_day_of_month)
+            if 'gte' in range_clause['range']['date'] and \
+            re.compile("^[0-9]{4}-[0-9]{1,2}$").match(range_clause['range']['date']['gte']):
+                range_clause['range']['date']['gte'] += "-1"
         dsl["and"].append(range_clause)
-
     return dsl
     
 def selected_filters_from_multidict(multidict, field):

--- a/sheer/test_filters.py
+++ b/sheer/test_filters.py
@@ -31,19 +31,20 @@ class testArgParsing(object):
         assert (('cats') in selected)
         assert (('dogs') in selected)
 
+class TestDateValidation(object):
     def test_date_validation_incorrect_range(self):
         args = MultiDict([('filter_range_date_gte', '2014-6'),
                           ('filter_range_date_lte', '2013-6')])
         filter_dsl = filters.filter_dsl_from_multidict(args)
-        assert(filter_dsl['and'][0]['range']['date']['gte'] == '2013-6')
-        assert(filter_dsl['and'][0]['range']['date']['lte'] == '2014-6')
+        assert(filter_dsl['and'][0]['range']['date']['gte'] == '2013-6-1')
+        assert(filter_dsl['and'][0]['range']['date']['lte'] == '2014-6-30')
 
     def test_date_validation_correct_range(self):
         args = MultiDict([('filter_range_date_gte', '2013-6'),
                           ('filter_range_date_lte', '2014-6')])
         filter_dsl = filters.filter_dsl_from_multidict(args)
-        assert(filter_dsl['and'][0]['range']['date']['gte'] == '2013-6')
-        assert(filter_dsl['and'][0]['range']['date']['lte'] == '2014-6')
+        assert(filter_dsl['and'][0]['range']['date']['gte'] == '2013-6-1')
+        assert(filter_dsl['and'][0]['range']['date']['lte'] == '2014-6-30')
 
     def test_date_validation_with_days_correct_range(self):
         args = MultiDict([('filter_range_date_gte', '2014-1-23'),
@@ -58,3 +59,18 @@ class testArgParsing(object):
         filter_dsl = filters.filter_dsl_from_multidict(args)
         assert(filter_dsl['and'][0]['range']['date']['gte'] == '2014-1-23')
         assert(filter_dsl['and'][0]['range']['date']['lte'] == '2014-6-23')
+
+    def test_default_days_correct_range(self):
+        args = MultiDict([('filter_range_date_gte', '2014-1'),
+                          ('filter_range_date_lte', '2014-6')])
+        filter_dsl = filters.filter_dsl_from_multidict(args)
+        print filter_dsl
+        assert(filter_dsl['and'][0]['range']['date']['gte'] == '2014-1-1')
+        assert(filter_dsl['and'][0]['range']['date']['lte'] == '2014-6-30')
+
+    def test_default_days_incorrect_range(self):
+        args = MultiDict([('filter_range_date_gte', '2014-6'),
+                          ('filter_range_date_lte', '2014-1')])
+        filter_dsl = filters.filter_dsl_from_multidict(args)
+        assert(filter_dsl['and'][0]['range']['date']['gte'] == '2014-1-1')
+        assert(filter_dsl['and'][0]['range']['date']['lte'] == '2014-6-30')


### PR DESCRIPTION
Before, a date range of 2014-1 through 2014-6 wouldn't return any results from June (the dates were defaulting to 2014-1-1 and 2014-6-1 respectively).  Now, those dates will default to 2014-1-1 and 2014-6-30 (first day of the month and last day of the month).

This also works when the dates are corrected, so 2014-6 through 2014-1 will also default to 2014-1-1 and 2014-6-30.  

You can still specify the day in the filter, and no defaults will be used.
