### PR TITLE
Removed default query sorting, added defaults to dateutil parse

### DIFF
--- a/sheer/filters.py
+++ b/sheer/filters.py
@@ -1,6 +1,7 @@
 import flask
 import re
 import calendar
+import datetime
 from dateutil.parser import parse
 
 def filter_dsl_from_multidict(multidict):
@@ -44,7 +45,8 @@ def filter_dsl_from_multidict(multidict):
         # If the 'start' date is after the 'end' date, swap them
         if 'date' in range_clause['range']:
             if all(x in range_clause['range']['date'] for x in ('lte', 'gte')) and \
-             parse(range_clause['range']['date']['gte']) > parse(range_clause['range']['date']['lte']):
+             parse(range_clause['range']['date']['gte'], default=datetime.date.today().replace(day=1)) > \
+             parse(range_clause['range']['date']['lte'], default=datetime.date.today().replace(day=1)):
                 range_clause['range']['date']['gte'], range_clause['range']['date']['lte'] = \
                 range_clause['range']['date']['lte'], range_clause['range']['date']['gte']
             # If either date matches the YYYY-M[M] format, append the appropriate day

--- a/sheer/query.py
+++ b/sheer/query.py
@@ -181,10 +181,6 @@ class Query(object):
         query_dict.update(kwargs)
         query_dict['body'] = query_body
 
-
-        if 'sort' not in query_dict:
-            query_dict['sort'] = "date:desc"
-
         response = self.es.search(**query_dict)
 
         response['query']= query_dict
@@ -197,9 +193,6 @@ class Query(object):
         query_dict = json.loads(file(self.filename).read())
         query_dict.update(kwargs)
         pagenum =1
-
-        if 'sort' not in query_dict:
-            query_dict['sort'] = "date:desc"
         
         request = flask.request
         filters = filter_dsl_from_multidict(request.args)

--- a/sheer/templates.py
+++ b/sheer/templates.py
@@ -6,7 +6,7 @@ from dateutil import parser
 
 def date_formatter(value, format="%Y-%m-%d"):
     if type(value) not in [datetime.datetime, datetime.date]:
-        dt = parser.parse(value)
+        dt = parser.parse(value, default=datetime.date.today().replace(day=1))
     else:
         dt = value
 

--- a/sheer/test_templates.py
+++ b/sheer/test_templates.py
@@ -1,0 +1,8 @@
+from sheer.templates import date_formatter
+
+class TestTemplates(object):
+
+	def test_templates(self):
+		date_string = '2012-02'
+		result = date_formatter(date_string)
+		assert(result == '2012-02-01')


### PR DESCRIPTION
A default date sort is no longer inserted into queries without a sort specified, fixing #49.  Sites will have to specify the desired sort (as they currently do with "sort": "date:desc" in the _queries/ files), otherwise the results will appear in seemingly random order.

Also, dateutil.parser.parse(date_string), when missing one or more date elements from the string, uses values from today's date by default to fill in the gaps.  For example, parse('2014-06') is missing the day, so it uses the current day when it creates the datetime object.  In this example, an error would be raised if it were to happen on the 31st because that day doesn't exist in June.  Now it will pass in the first day of the current month as a default, which should fix it.
