### PR TITLE
Added trailing slash to feeds route

### DIFF
--- a/sheer/feeds.py
+++ b/sheer/feeds.py
@@ -10,7 +10,7 @@ def make_external(url):
 
 def add_feeds_to_sheer(app):
 
-    @app.route('/feed/<name>')
+    @app.route('/feed/<name>/')
     def recent_feed(name):
         feed = AtomFeed('Consumer Financial Protection Bureau - {}'.format(name), 
                         feed_url=request.url, 


### PR DESCRIPTION
For feeds, adding a trailing slash was causing a 404.  Now, without a trailing slash, it will redirect to the trailing slash.  Trailing slash will also work.
