### PR TITLE
fix for trailing slash

### DIFF
--- a/sheer/wsgi.py
+++ b/sheer/wsgi.py
@@ -85,7 +85,7 @@ def app_with_config(config):
         seeker_handler = functools.partial(handle_request, diskpath=here)
         index_handler = functools.partial(handle_request, diskpath=here, remainder=None)
 
-        seeker_url = relurl + '<remainder>'
+        seeker_url = relurl + '<remainder>/'
         index_url = relurl
 
         seeker_view_name = relurl.replace('/','_')


### PR DESCRIPTION
This MOSTLY fixes the problems we were having with trailing slashes.  There is a corresponding change to sheer_blog's lookups.json required for this to work.

Previously, using a trailing slash on a URL created 404s (see #43)

Now, URLs without trailing slashes will be redirected to the trailing slash version. Going directly to the trailing slash version also works.

One known bug is that now a slash gets added to filenames as well, ie. typing in localhost:7000/blog/index.html turns into localhost:7000/blog/index.html/ (on the bright side, the page still loads).

So, while not yet a perfected solution, this is still much better than getting 404s when trailing slashes are used.
