### PR TITLE
Added type_for_url for more accurate permalinks

### DIFF
--- a/sheer/query.py
+++ b/sheer/query.py
@@ -78,12 +78,13 @@ class QueryHit(object):
     def __init__(self, hit_dict, es=None, es_index=None):
         self.hit_dict = hit_dict
         self.type = hit_dict['_type']
+        self.type_for_url = hit_dict['_source'].get('type_for_url') or hit_dict['_type']
         self.mapping = mapping_for_type(self.type, es=es, es_index=es_index )
 
     @property
     def permalink(self):
         app = flask.current_app
-        rule = app.permalinks_by_type.get(self.type)
+        rule = app.permalinks_by_type.get(self.type_for_url)
         if rule:
             build_with=dict(id = self.hit_dict['_id'])
             _ , url = rule.build(build_with)


### PR DESCRIPTION
Before, when permalinks were created, they were using the rule dictated by the post type where the post was indexed in ES.  

For example: if we have two post types, /a/ and /b/.  We want to include a few of the /a/ posts in /b/, but their permalinks are showing up as /b/slug even though they are of type /a/.

Now if you send a 'type_for_url' into the hit_dict, the permalink will reflect the proper type.
