### PR TITLE
don't coerce None to string

### DIFF
--- a/sheer/query.py
+++ b/sheer/query.py
@@ -53,7 +53,7 @@ def datatype_for_fieldname_in_mapping(fieldname, hit_type, mapping_dict):
         return None
 
 def coerced_value(value, datatype):
-    if datatype == None:
+    if datatype == None or value == None:
         return value
 
     TYPE_MAP={'string': unicode,


### PR DESCRIPTION
Previously, if a value was None, but that field was mapped to "string", None was being coerced into a string.

None shouldn't need to be coerced into a string (or any other type).  In templates, "if [variable that should be None]" was returning True because "None" is an actual string.
