### PR TITLE
Added boolean to coerced_value()

### DIFF
--- a/sheer/query.py
+++ b/sheer/query.py
@@ -60,7 +60,8 @@ def coerced_value(value, datatype):
               'date': dateutil.parser.parse,
               'dict': dict,
               'float':float,
-              'long':float}
+              'long':float,
+              'boolean': bool}
 
     coercer = TYPE_MAP[datatype]
 


### PR DESCRIPTION
Sheer was failing to handle a boolean type in `coerced_value()`, so I added that type to the TYPE_MAP.  This removes the KeyError: 'boolean' when trying to access a boolean value from a jinja2 template.
