### PR TITLE
Fixes to maintain support for python 2.6

### DIFF
--- a/sheer/feeds.py
+++ b/sheer/feeds.py
@@ -19,7 +19,7 @@ def make_external(url):
 def get_feed_settings(name):
     app = flask.current_app
     queries_dir = os.path.join(app.root_dir,'_queries')
-    query_path = os.path.join(queries_dir, '{}.json'.format(name))
+    query_path = os.path.join(queries_dir, '{0}.json'.format(name))
     if os.path.exists(query_path):
         query_file = read_json_file(query_path)
         return query_file.get('feed')

--- a/sheer/filters.py
+++ b/sheer/filters.py
@@ -52,7 +52,7 @@ def filter_dsl_from_multidict(multidict):
             re.compile("^[0-9]{4}-[0-9]{1,2}$").match(range_clause['range']['date']['lte']):
                 year, month = range_clause['range']['date']['lte'].split('-')
                 last_day_of_month = calendar.monthrange(int(year), int(month))[1]
-                range_clause['range']['date']['lte'] += "-{}".format(last_day_of_month)
+                range_clause['range']['date']['lte'] += "-{0}".format(last_day_of_month)
             if 'gte' in range_clause['range']['date'] and \
             re.compile("^[0-9]{4}-[0-9]{1,2}$").match(range_clause['range']['date']['gte']):
                 range_clause['range']['date']['gte'] += "-1"

--- a/sheer/indexer.py
+++ b/sheer/indexer.py
@@ -2,17 +2,15 @@ import os
 import sys
 import codecs
 
-
-try:
-    # Python 2.7
-    from collections import OrderedDict
-    import json
-
-except ImportError:
+if sys.version_info[0:2] == (2,6):
     # Python 2.6
-    # the json included in 2.6 doesn't support oject_pairs_hook
+    # the json included in 2.6 doesn't support object_pairs_hook
     from ordereddict import OrderedDict
     import simplejson as json
+else:
+    # Python 2.7 or higher
+    from collections import OrderedDict
+    import json
 
 
 import copy

--- a/sheer/wsgi.py
+++ b/sheer/wsgi.py
@@ -106,7 +106,7 @@ def app_with_config(config):
             try:
                 blueprint = __import__(package, fromlist=[module])
             except ImportError:
-                print "Error importing package {}".format(key)
+                print "Error importing package {0}".format(key)
                 continue
             app.register_blueprint(getattr(blueprint, module))
 


### PR DESCRIPTION
Two very small changes here that were causing problems in 2.6:
1. Substitution using "{} {} {}".format(a, b, c) requires explicit indices in 2.6 e.g. "{0} {1} {2}"
2. The previous check for python 2.6 in indexer.py wasn't picking up 2.6.6, and therefore was trying to run python 2.7+ code
