### PR TITLE
Reverses the existing logic: a *seeker* URL will never end in a slash, and an index URL ALWAYS will.

### DIFF
--- a/sheer/wsgi.py
+++ b/sheer/wsgi.py
@@ -86,8 +86,8 @@ def app_with_config(config):
         seeker_handler = functools.partial(handle_request, diskpath=here)
         index_handler = functools.partial(handle_request, diskpath=here, remainder=None)
 
-        seeker_url = relurl + '<remainder>/'
-        index_url = relurl
+        seeker_url = relurl + '<remainder>'
+        index_url = relurl + '/'
 
         seeker_view_name = relurl.replace('/','_')
         index_view_name = seeker_view_name + '_index'


### PR DESCRIPTION
Such that, given a sheer site with path:

/foo/bar.html
/foo/index.html

/foo/bar.html serves the file
/foo/bar.html/ 404 error
/foo/     serves index.html
/foo      redirects to /foo/

This seems to me to be the correct way for it to work. @dpford can you test it out?
