### PR TITLE
Redirect to relative URL

### DIFF
--- a/sheer/views.py
+++ b/sheer/views.py
@@ -40,7 +40,7 @@ def handle_request(lookup_name=None, lookup_config=None, **kwargs):
     translated_path = os.path.join(root_dir, request_path[1:])
 
     if os.path.isdir(translated_path) and not request_path.endswith('/'):
-            return flask.redirect(request_path+'/')
+            return flask.redirect(request_path[1:]+'/')
 
     if not request_path.endswith('.html') and os.path.exists(translated_path):
         mime, encoding = mimetypes.guess_type(complete_path)


### PR DESCRIPTION
In the case that sheer isn't being run at the root of the site's URL, the redirect with trailing slash was redirecting to the root of the site.

For example:

sheer is being run at /store/ (but store isn't actually a folder on the server), and you try to go to /store/product, it was redirecting to /product/.  Now it redirects to a relative URL by getting rid of the first slash, correctly redirecting to /store/product/
