### PR TITLE
make it so sheer doesn't index the _tests folder

### DIFF
--- a/sheer/indexer.py
+++ b/sheer/indexer.py
@@ -24,7 +24,12 @@ from elasticsearch import Elasticsearch
 from sheer.utility import add_site_libs
 from sheer.processors.helpers import IndexHelper
 
-DO_NOT_INDEX = ['_settings/', '_layouts/', '_queries/', '_defaults/', '_lib/']
+DO_NOT_INDEX = ['_settings/', 
+                '_layouts/', 
+                '_queries/', 
+                '_defaults/', 
+                '_lib/',
+                '_tests/']
 
 
 def read_json_file(path):


### PR DESCRIPTION
We need a place to put browser tests, and we don't want it to be indexed by sheer or clutter up the actual browsable folders, so _tests fits the bill.
