### PR TITLE
Add string representation for QueryHit object

### DIFF
--- a/sheer/query.py
+++ b/sheer/query.py
@@ -84,6 +84,12 @@ class QueryHit(object):
         self.type = hit_dict['_type']
         self.mapping = mapping_for_type(self.type, es=es, es_index=es_index)
 
+    def __str__(self):
+        return str(self.hit_dict.get('_source'))
+
+    def __repr__(self):
+        return self.__str__()
+
     @property
     def permalink(self):
         app = flask.current_app


### PR DESCRIPTION
To make it easier to inspect objects from within templates, this returns the `_source` data when __str__ is called.