### PR TITLE
allow filter_ syntax as arguments in template queries

### DIFF
--- a/sheer/query.py
+++ b/sheer/query.py
@@ -174,11 +174,29 @@ class Query(object):
     def search_with_url_arguments(self, term_facets=None, **kwargs):
         query_file = json.loads(file(self.filename).read())
         query_dict = query_file['query']
-        query_dict.update(kwargs)
+
+        '''
+        These dict constructors split the kwargs from the template into filter
+        arguments and arguments that can be placed directly into the query body.
+        The dict constructor syntax supports python 2.6, 2.7, and 3.x
+        If python 2.7, use dict comprehension and iteritems()
+        With python 3, use dict comprehension and items() (items() replaces 
+        iteritems and is just as fast)
+        '''
+        filter_args = dict((key, value) for (key, value) in kwargs.items() 
+            if key.startswith('filter_'))
+        non_filter_args = dict((key, value) for (key, value) in kwargs.items() 
+            if not key.startswith('filter_'))
+        query_dict.update(non_filter_args)
         pagenum = 1
 
         request = flask.request
-        url_filters = filter_dsl_from_multidict(request.args)
+
+        # Add in filters from the template.
+        new_multidict = request.args.copy()
+        for key, value in filter_args.items():
+            new_multidict.add(key, value)
+        url_filters = filter_dsl_from_multidict(new_multidict)
         args_flat = request.args.to_dict(flat=True)
         query_body = {}
 


### PR DESCRIPTION
Previously, search_with_url_filters(), what is primarily used for running ElasticSearch queries from within a template, only took in the standard arguments from elasticsearch-py's search() method.  Filtering was not one of those, so we were forced to use queries instead of filters for our data (slower, not the right way to do things).

Now, filters can be entered as arguments into search_with_url_filters() using the same syntax as URL filters:

`filter_range_fieldname_operator` for range filters

`filter_fieldname` for bool filters

Caveat: these continue to use the "should" option of combined filters.  This means they are treated as OR.  For more complex filters (AND, NOT, etc.), use a raw query in /_queries/