### PR TITLE
Reworked bool filters to make more sense for real world usage

### DIFF
--- a/sheer/filters.py
+++ b/sheer/filters.py
@@ -4,65 +4,75 @@ import calendar
 import datetime
 from dateutil.parser import parse
 
+def generate_term_filters(multidict, filter_keys):
+    term_main = {"and": []}
+    for key in filter_keys:
+        field = key.replace('filter_', '')
+        filter_type_main = {"or": []}
+        values = multidict.getlist(key)
+        for val in values:
+            term_single = {"term": {}}
+            term_single["term"][field] = val
+            filter_type_main["or"].append(term_single)
+        term_main["and"].append(filter_type_main)
+    return term_main
+
+def generate_range_filters(multidict, filter_keys):
+    range_clause = {"range": {}}
+    for key in filter_keys:
+        full_field = key.replace('filter_range_', '')
+        # We account for potential underscores in the field name itself
+        # e.g. comment_count
+        operator = full_field[full_field.rfind('_') + 1:]
+        field = full_field[:full_field.rfind('_')]
+        if field not in range_clause["range"]:
+            range_clause["range"][field] = {}
+        # If there are multiples of the same date filter, this will take
+        # the first
+        value = multidict.getlist(key)[0]
+        range_clause["range"][field][operator] = value
+
+    # Validate date range input
+
+    # First check if both date_lte and date_gte are present
+    # If the 'start' date is after the 'end' date, swap them
+    if 'date' in range_clause['range']:
+        if all(x in range_clause['range']['date'] for x in ('lte', 'gte')) and \
+            parse(range_clause['range']['date']['gte'], default=datetime.date.today().replace(day=1)) > \
+                parse(range_clause['range']['date']['lte'], default=datetime.date.today().replace(day=1)):
+            range_clause['range']['date']['gte'], range_clause['range']['date']['lte'] = \
+                range_clause['range']['date'][
+                    'lte'], range_clause['range']['date']['gte']
+        # If either date matches the YYYY-M[M] format, append the
+        # appropriate day
+        if 'lte' in range_clause['range']['date'] and \
+                re.compile("^[0-9]{4}-[0-9]{1,2}$").match(range_clause['range']['date']['lte']):
+            year, month = range_clause['range']['date']['lte'].split('-')
+            last_day_of_month = calendar.monthrange(
+                int(year), int(month))[1]
+            range_clause['range']['date'][
+                'lte'] += "-{0}".format(last_day_of_month)
+        if 'gte' in range_clause['range']['date'] and \
+                re.compile("^[0-9]{4}-[0-9]{1,2}$").match(range_clause['range']['date']['gte']):
+            range_clause['range']['date']['gte'] += "-1"
+    return range_clause
+
+
 
 def filter_dsl_from_multidict(multidict):
-    # Split the filters between 'range' and 'bool', making sure the query
+    # Split the filters between 'range' and 'term', making sure the query
     # value isn't blank
-    bool_filter_keys = [r for r in [k for k in multidict.keys() if re.compile("^filter_(?!range_)").match(k)]
+    term_filter_keys = [r for r in [k for k in multidict.keys() if re.compile("^filter_(?!range_)").match(k)]
                         if multidict[r]]
     range_filter_keys = [r for r in [k for k in multidict.keys() if re.compile("^filter_range_").match(k)]
                          if multidict[r]]
-
     final_filters = []
-    if bool_filter_keys:
-        bool_clause = {"bool": {"must": [], "should": [], "must_not": []}}
-        for key in bool_filter_keys:
-            field = key.replace('filter_', '')
-            values = multidict.getlist(key)
-            for val in values:
-                term_clause = {"term": {}}
-                term_clause["term"][field] = val
-                bool_clause["bool"]["should"].append(term_clause)
-        final_filters.append(bool_clause)
-
+    if term_filter_keys:
+        term_clause = generate_term_filters(multidict, term_filter_keys)
+        final_filters.append(term_clause)
+        
     if range_filter_keys:
-        range_clause = {"range": {}}
-        for key in range_filter_keys:
-            full_field = key.replace('filter_range_', '')
-            # We account for potential underscores in the field name itself
-            # e.g. comment_count
-            operator = full_field[full_field.rfind('_') + 1:]
-            field = full_field[:full_field.rfind('_')]
-            if field not in range_clause["range"]:
-                range_clause["range"][field] = {}
-            # If there are multiples of the same date filter, this will take
-            # the first
-            value = multidict.getlist(key)[0]
-            range_clause["range"][field][operator] = value
-
-        # Validate date range input
-
-        # First check if both date_lte and date_gte are present
-        # If the 'start' date is after the 'end' date, swap them
-        if 'date' in range_clause['range']:
-            if all(x in range_clause['range']['date'] for x in ('lte', 'gte')) and \
-                parse(range_clause['range']['date']['gte'], default=datetime.date.today().replace(day=1)) > \
-                    parse(range_clause['range']['date']['lte'], default=datetime.date.today().replace(day=1)):
-                range_clause['range']['date']['gte'], range_clause['range']['date']['lte'] = \
-                    range_clause['range']['date'][
-                        'lte'], range_clause['range']['date']['gte']
-            # If either date matches the YYYY-M[M] format, append the
-            # appropriate day
-            if 'lte' in range_clause['range']['date'] and \
-                    re.compile("^[0-9]{4}-[0-9]{1,2}$").match(range_clause['range']['date']['lte']):
-                year, month = range_clause['range']['date']['lte'].split('-')
-                last_day_of_month = calendar.monthrange(
-                    int(year), int(month))[1]
-                range_clause['range']['date'][
-                    'lte'] += "-{0}".format(last_day_of_month)
-            if 'gte' in range_clause['range']['date'] and \
-                    re.compile("^[0-9]{4}-[0-9]{1,2}$").match(range_clause['range']['date']['gte']):
-                range_clause['range']['date']['gte'] += "-1"
+        range_clause = generate_range_filters(multidict, range_filter_keys)
         final_filters.append(range_clause)
     return final_filters
 

--- a/sheer/filters.py
+++ b/sheer/filters.py
@@ -5,6 +5,12 @@ import datetime
 from dateutil.parser import parse
 
 def generate_term_filters(multidict, filter_keys):
+    '''
+    This generates the ElasticSearch filter DSL for filters that check whether
+    a field matches a certain string.  Groupings of the same exact filter, such
+    as filter_fieldname, are combined into an OR filter, while the major
+    groupings of separate filters are all combined into an AND filter.
+    '''
     term_main = {"and": []}
     for key in filter_keys:
         field = key.replace('filter_', '')
@@ -18,6 +24,10 @@ def generate_term_filters(multidict, filter_keys):
     return term_main
 
 def generate_range_filters(multidict, filter_keys):
+    '''
+    This generates the ElasticSearch filter DSL for filters that check whether
+    a field is within a certain range
+    '''
     range_clause = {"range": {}}
     for key in filter_keys:
         full_field = key.replace('filter_range_', '')

--- a/sheer/test_filters.py
+++ b/sheer/test_filters.py
@@ -3,22 +3,25 @@ from werkzeug.datastructures import MultiDict
 from sheer import filters
 
 
-class testArgParsing(object):
+class TestArgParsing(object):
 
     def setup(self):
         self.args = MultiDict([('filter_category', 'cats'),
                                ('filter_category', 'dogs'),
+                               ('filter_planet', 'earth'),
                                ('filter_range_date_lte', '2014-6-1'),
                                ('filter_range_comment_count_gt', '100')])
 
     def test_args_to_filter_dsl(self):
         filter_dsl = filters.filter_dsl_from_multidict(self.args)
-        assert('bool' in filter_dsl[0])
-        assert('must' in filter_dsl[0]['bool'])
-        value1 = filter_dsl[0]['bool']['should'][0]['term']['category']
-        value2 = filter_dsl[0]['bool']['should'][1]['term']['category']
+        print filter_dsl
+        assert('and' in filter_dsl[0])
+        assert('or' in filter_dsl[0]['and'][0])
+        value1 = filter_dsl[0]['and'][0]['or'][0]['term']['category']
+        value2 = filter_dsl[0]['and'][0]['or'][1]['term']['category']
         assert('cats' in [value1, value2])
         assert('dogs' in [value1, value2])
+        assert('earth' in filter_dsl[0]['and'][1]['or'][0]['term']['planet'])
 
     def test_range_args(self):
         filter_dsl = filters.filter_dsl_from_multidict(self.args)


### PR DESCRIPTION
Previously, all non-range ElasticSearch filters were being thrown into an OR filter.  A result would just have to satisfy any one of the filter choices to be returned.

![](http://deansomerset.com/wp-content/uploads/2014/12/pzv5j7l.jpg)

If you're filtering blog posts by different fields (author, tags, date), those should be joined by an AND filter.  The set returned should satisfy all of those constraints.  Within a particular field (for example, multiple authors), that filter should be joined by an OR filter.  Each blog post returned should be written by one of the authors selected.

If that explanation sounds good, then this PR is for you!