### PR TITLE
Switch out term facets for aggregations

### DIFF
--- a/sheer/query.py
+++ b/sheer/query.py
@@ -130,10 +130,6 @@ class QueryResults(object):
             for hit in self.result_dict['hits']['hits']:
                 yield QueryHit(hit)
 
-    def facets(self, fieldname):
-        if "facets" in self.result_dict and fieldname in self.result_dict["facets"]:
-            return self.result_dict['facets'][fieldname]["terms"]
-
     def aggregations(self, fieldname):
         if "aggregations" in self.result_dict and \
             fieldname in self.result_dict['aggregations']:


### PR DESCRIPTION
NOTE: There is a complementary cfgov-refresh PR that should be merged at the same time as this one: https://github.com/cfpb/cfgov-refresh/pull/285

Facets are deprecated in ElasticSearch and will be removed in a future release.  This migrates them to aggregations which work pretty much the same way as facets.

Sites that previously used terms facet with sheer will need to make slight modifications to their code.  The iterable that is returned by possible_values_for now looks like {"key": "term-you-want"} instead of {"term": "term-you-want"}.