### PR TITLE
Partial indexing and reindexing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ Werkzeug==0.9.1
 autopep8==0.9.2
 elasticsearch==0.4.3
 itsdangerous
+mock==1.0.1
 nose==1.3.0
 pep8==1.4.6
 python-dateutil==2.1

--- a/sheer/indexer.py
+++ b/sheer/indexer.py
@@ -19,8 +19,6 @@ import importlib
 
 from csv import DictReader
 
-# For some reason mock has difficulty mocking Elasticsearch if it's imported
-# from the elasticsearch module.
 from elasticsearch import Elasticsearch
 from elasticsearch.exceptions import TransportError
 

--- a/sheer/scripts/sheer
+++ b/sheer/scripts/sheer
@@ -25,13 +25,17 @@ if __name__ == '__main__':
 
     index_parser = subparsers.add_parser('index',
                                          help='load content into Elasticsearch')
-
+    index_parser.add_argument('--reindex', '-r', action="store_true",
+                              help="recreate the index and reindex all content")
+    index_parser.add_argument('--processors', '-p', nargs='*',
+                              help='content processors to index')
     index_parser.set_defaults(func=sheer.indexer.index_location)
+
     server_parser=subparsers.add_parser('serve', help= "serve content from elasticsearch, using configuration and templates at location")
     server_parser.set_defaults(func=sheer.server.serve_wsgi_app_with_cli_args)
-    server_parser.add_argument('--port', '-p', 
+    server_parser.add_argument('--port', '-p',
             default= '7000', help="port to run the web server on")
-    server_parser.add_argument('--addr', '-a', 
+    server_parser.add_argument('--addr', '-a',
             default= '0.0.0.0', help="address to run the web server on")
 
     build_parser=subparsers.add_parser('build', help='generate a static version of this site')

--- a/sheer/test_indexing.py
+++ b/sheer/test_indexing.py
@@ -157,7 +157,7 @@ class TestIndexing(object):
         # Here we want to test:
         #   * Index exists -> should be left alone
         #   * Mappings exist for processor -> should be deleted and recreated
-        #   * Documents exist for processor -> should be updated
+        #   * Documents don't exist for processor -> should be created
 
         mock_es = mock_Elasticsearch.return_value
         mock_es.indices.exists.return_value = True
@@ -170,12 +170,11 @@ class TestIndexing(object):
         test_args = AttrDict(processors=['posts'], reindex=False)
         index_location(test_args, self.config)
 
-        mock_es.update.assert_called_with(
+        mock_es.create.assert_called_with(
             index=self.config['index'],
             doc_type='posts',
             id=self.mock_document['_id'],
-            body={'doc':self.mock_document})
-
+            body=self.mock_document)
 
     @mock.patch('sheer.indexer.Elasticsearch')
     @mock.patch('sheer.indexer.ContentProcessor')

--- a/sheer/test_indexing.py
+++ b/sheer/test_indexing.py
@@ -14,8 +14,10 @@ class TestIndexing(object):
     """
 
     def setup(self):
-        # Sheer indexing loads three JSON files. These are mocked here for the
-        # purpose of testing.
+        # Sheer indexing tries to load three JSON files. For testing purposes,
+        # `settings.json` and `mappings.json` are not necessary, but we do need
+        # a content processor to test with. The contents of `processors.json` is
+        # mocked here.
         self.mock_processors = {'posts':
             {'url': 'http://test/api/get_posts/',
              'processor': 'post_processor',

--- a/sheer/test_indexing.py
+++ b/sheer/test_indexing.py
@@ -11,9 +11,6 @@ class AttrDict(dict):
 class TestIndexing(object):
     """
     Test Sheer content indexing.
-
-    Sheer indexes content based on settings, mappings, and content
-    processors defined in
     """
 
     def setup(self):

--- a/sheer/test_indexing.py
+++ b/sheer/test_indexing.py
@@ -1,0 +1,180 @@
+
+import mock
+from .indexer import ContentProcessor, index_location
+from elasticsearch.exceptions import TransportError
+
+class AttrDict(dict):
+    def __init__(self, *args, **kwargs):
+        super(AttrDict, self).__init__(*args, **kwargs)
+        self.__dict__ = self
+
+class TestIndexing(object):
+    """
+    Test Sheer content indexing.
+
+    Sheer indexes content based on settings, mappings, and content
+    processors defined in
+    """
+
+    def setup(self):
+        # Sheer indexing loads three JSON files. These are mocked here for the
+        # purpose of testing.
+        self.mock_processors = {'posts':
+            {'url': 'http://test/api/get_posts/',
+             'processor': 'post_processor',
+             'mappings': '_settings/posts_mappings.json'}}
+        self.mock_processor_mappings = '''{}'''
+        self.mock_document = {
+            '_id': u'a-great-post-slug',
+        }
+
+        self.config = {'location': '.',
+                       'elasticsearch': '',
+                       'index': 'content',}
+
+        # This is our mock ContentProcessor. It will return mappings and
+        # documents for a particular document type, 'posts' in our mock
+        # scenario. documents() returns a generator, which requires us to mock
+        # its iterator.
+        self.mock_processor = mock.Mock(spec=ContentProcessor)
+        self.mock_processor.name = 'posts'
+        self.mock_processor.processor_name = 'posts_processor'
+        self.mock_processor.mapping.return_value = {}
+        self.mock_processor.documents.return_value = iter([self.mock_document])
+
+
+    @mock.patch('sheer.indexer.Elasticsearch')
+    @mock.patch('sheer.indexer.ContentProcessor')
+    @mock.patch('sheer.indexer.read_json_file')
+    @mock.patch('os.path.exists')
+    def test_indexing(self, mock_exists, mock_read_json_file,
+                      mock_ContentProcessor, mock_Elasticsearch):
+        """
+        `sheer index`
+
+        Test the creation of indexes by Sheer. For a given index, if it
+        does not exist, it should be created and the documents yeilded
+        by a given set of content processors should be created.
+        """
+        # Mock file existing/opening/reading
+        # os.path.exists is only called directly for settings.json and
+        # mappings.json, which are not necessary for our tests.
+        mock_exists.return_value = False
+        mock_read_json_file.side_effect = [self.mock_processors, {}]
+
+        # Wire-up our mock content processor
+        mock_ContentProcessor.return_value = self.mock_processor
+
+        # Here we want to test:
+        #   * Index doesn't exist -> should be created
+        #   * Mappings don't exist for processor -> should be created
+        #   * Documents don't exist for processor -> should be created
+        mock_es = mock_Elasticsearch.return_value
+        mock_es.indices.exists.return_value = False
+        mock_es.indices.get_mapping.return_value = None
+
+        test_args = AttrDict(processors=[], reindex=False)
+        index_location(test_args, self.config)
+
+        mock_es.indices.create.assert_called_with(index=self.config['index'])
+        mock_es.indices.put_mapping.assert_called_with(
+            index=self.config['index'],
+            doc_type='posts',
+            body={'posts': {}})
+        mock_es.create.assert_called_with(
+            index=self.config['index'],
+            doc_type='posts',
+            id=self.mock_document['_id'],
+            body=self.mock_document)
+
+
+    @mock.patch('sheer.indexer.Elasticsearch')
+    @mock.patch('sheer.indexer.ContentProcessor')
+    @mock.patch('sheer.indexer.read_json_file')
+    @mock.patch('os.path.exists')
+    def test_reindexing(self, mock_exists, mock_read_json_file,
+                      mock_ContentProcessor, mock_Elasticsearch):
+        """
+        `sheer index --reindex`
+
+        Test the re-creation of existing indexes by Sheer. For a given
+        index, if it already exists, it should be removed and recreated.
+        """
+        # Mock file existing/opening/reading
+        # os.path.exists is only called directly for settings.json and
+        # mappings.json, which are not necessary for our tests.
+        mock_exists.return_value = False
+        mock_read_json_file.side_effect = [self.mock_processors, {}]
+
+        # Wire-up our mock content processor
+        mock_ContentProcessor.return_value = self.mock_processor
+
+        # Here we want to test:
+        #   * Index exists -> should be deleted and recreated.
+        #   ... therefore ...
+        #   * Mappings don't exist for processor -> should be created
+        #   * Documents don't exist for processor -> should be created
+        mock_es = mock_Elasticsearch.return_value
+        mock_es.indices.exists.side_effect = [True, False]
+        mock_es.indices.get_mapping.return_value = None
+
+        test_args = AttrDict(processors=[], reindex=True)
+        index_location(test_args, self.config)
+
+        mock_es.indices.delete.assert_called_with(self.config['index'])
+        mock_es.indices.create.assert_called_with(index=self.config['index'])
+        mock_es.indices.put_mapping.assert_called_with(
+            index=self.config['index'],
+            doc_type='posts',
+            body={'posts': {}})
+        mock_es.create.assert_called_with(
+            index=self.config['index'],
+            doc_type='posts',
+            id=self.mock_document['_id'],
+            body=self.mock_document)
+
+
+    @mock.patch('sheer.indexer.Elasticsearch')
+    @mock.patch('sheer.indexer.ContentProcessor')
+    @mock.patch('sheer.indexer.read_json_file')
+    @mock.patch('os.path.exists')
+    def test_partial_indexing(self, mock_exists, mock_read_json_file,
+                      mock_ContentProcessor, mock_Elasticsearch):
+        """
+        `sheer index --processors posts`
+
+        Test partial indexing of the document type associated with a
+        content processor.
+        """
+        # Mock file existing/opening/reading
+        # os.path.exists is only called directly for settings.json and
+        # mappings.json, which are not necessary for our tests.
+        mock_exists.return_value = False
+        mock_read_json_file.side_effect = [self.mock_processors, {}]
+
+        # Wire-up our mock content processor
+        mock_ContentProcessor.return_value = self.mock_processor
+
+        # Here we want to test:
+        #   * Index exists -> should be left alone
+        #   * Mappings exist for processor -> should be deleted and recreated
+        #   * Documents don't exist for processor -> should be updated
+
+        mock_es = mock_Elasticsearch.return_value
+        mock_es.indices.exists.return_value = True
+        # The tests for the get_mapping return value simply need to evaluate to
+        # True in indexer.py.
+        mock_es.indices.get_mapping.return_value = True
+        mock_create_exception = TransportError(409)
+        mock_es.create.side_effect = mock_create_exception
+
+        test_args = AttrDict(processors=['posts'], reindex=False)
+        index_location(test_args, self.config)
+
+        mock_es.update.assert_called_with(
+            index=self.config['index'],
+            doc_type='posts',
+            id=self.mock_document['_id'],
+            body={'doc':self.mock_document})
+
+


### PR DESCRIPTION
This PR adds partial indexing to Sheer. It does this by slightly changing the behavior of `sheer index`. Before this PR, if the index already existed `sheer index` would destroy the existing index in Elasticsearch, recreate it, then fetch documents from each content processor and add them to Elasticsearch. After this PR, if the index does not exist, `sheer index` behaves exactly as before. If it *does* exist: 

- `sheer index` If the index *does* exist, it will be left alone, and content will be [updated](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-update.html) 
- `sheer index --reindex` If the index *does* exist, it will be deleted and recreated, and all content refetched.
- `sheer index --processors [content processor] [content processor] ...` 
    - If the index *does not* exist, it will be created, and then *only content fetched by the given processors* will be added.
    - If the index *does* exist, content fetched by the given processors will be [updated](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-update.html)
- `sheer index --processors [content processor] [content processor] --reindex` If the index *does* exist, the mapping for the given processors will be deleted and recreated and all content fetched by the given processors will be re-added.

**Additions**
 
- Added `--reindex` option
- Added `--processors` option
- Added unittests for indexing.
 
**Changes**
 
- Changed the default behavior of `index` when the index already exists
 
**Testing**
 
- `nodetests` from the root of the repository
- `nodetests sheer/test_indexing.py` from the root of the repository to only test indexing.
 
**Review**
 
- @dpford 
- @rosskarchner 
 