### PR TITLE
Remove the bell

### DIFF
--- a/sheer/wsgi.py
+++ b/sheer/wsgi.py
@@ -47,7 +47,6 @@ class Sheer(flask.Flask):
                                         append=['_layouts', '_includes'],
                                         include_start_directory=True)
 
-        print "\a"
         return FileSystemLoader(search_path)
 
     def dispatch_request(self):


### PR DESCRIPTION
**Additions**
 
- Sanity
 
**Removals**
 
- Removed the use of the terminal bell 
 
**Changes**
 
- The mental landscape of serving content with Sheer. 
 
**Testing**
 
- Run `sheer serve`. Visit http://localhost:7000. Enjoy silence as you browse.
 
**Review**
 
- @dpford 
- @rosskarchner 
 
**Preview**
 
Imagine yourself in a room without bells.
 
**Notes**
 
- I know I can disable the bell. I can't disable the little red notification dot on Terminal.app. If there are good reasons for the bell, we can close this, but I'm having trouble imagining them.