### PR TITLE
Gracefully handle JSON ValueErrors when Indexing

### DIFF
--- a/sheer/indexer.py
+++ b/sheer/indexer.py
@@ -121,15 +121,14 @@ def index_processor(es, index_name, default_mapping, processor, reindex=False):
         # print an error message and raise the exception. It should be caught by
         # this function's caller.
         sys.stderr.write("error reading documents for %s" % processor.name)
-        raise
+    else:
+        i = -1
+        for i, document in document_iterator:
+            index_document(es, index_name, processor, document)
+            sys.stdout.write("indexed %s %s \r" % (i + 1, processor.name))
+            sys.stdout.flush()
 
-    i = -1
-    for i, document in document_iterator:
-        index_document(es, index_name, processor, document)
-        sys.stdout.write("indexed %s %s \r" % (i + 1, processor.name))
-        sys.stdout.flush()
-
-    sys.stdout.write("indexed %s %s \n" % (i + 1, processor.name))
+        sys.stdout.write("indexed %s %s \n" % (i + 1, processor.name))
 
 
 def index_location(args, config):
@@ -206,11 +205,5 @@ def index_location(args, config):
         selected_processors = [p for p in processors if p.name in args.processors]
 
     for processor in selected_processors:
-        # This could raise a value error if there's a problem reading the
-        # processor's source json. If that happens, continue on to the next
-        # content processor.
-        try:
-            index_processor(es, index_name, default_mapping, processor, reindex=args.reindex)
-        except ValueError:
-            continue
+        index_processor(es, index_name, default_mapping, processor, reindex=args.reindex)
 


### PR DESCRIPTION
This PR handles ValueErrors that occur during indexing more gracefully. ValueErrors may be thrown by content processors when `json.loads()` is unable to parse JSON that's received. That could be because of errors on the side providing the JSON, or because of malformed JSON being returned. In either case, before this change Sheer would bail completely. This PR will have Sheer print an error to stderr and then continue on to the next content processor, so the indexing process as a whole does not fail, just the indexing process for the content processor that's experiencing the error.
 
**Changes**
 
- Gracefully handle ValueErrors raised by content processors during indexing.
 
**Testing**
 
- `nodetests` from the root of the repository
- `nodetests sheer/test_indexing.py` from the root of the repository to only test indexing.
 
**Review**
 
- @dpford 
- @rosskarchner 
 