### PR TITLE
Bring text from "Understanding Sheer" wiki page into README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,122 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.
+

--- a/README.md
+++ b/README.md
@@ -140,23 +140,23 @@ sheer serve --debug
 
 The `sheer` command takes the following general arguments:
 
-* `-h`: show help message and exit
-* `--debug`: print debugging output to the console
-* `--location`: the directory you want to operate on. You can also set
-  the `SHEER_LOCATION` environment variable
-* `--elasticsearch ELASTICSEARCH, -e ELASTICSEARCH`: elasticsearch
+* `-h`: Show help message and exit.
+* `--debug`: Print debugging output to the console.
+* `--location`: The directory you want to operate on. You can also set
+  the `SHEER_LOCATION` environment variable.
+* `--elasticsearch ELASTICSEARCH, -e ELASTICSEARCH`: Elasticsearch
   host:port pairs. Seperate hosts with commas. Default is
   `localhost:9200` You can also set the `SHEER_ELASTICSEARCH_HOSTS`
   environment variable.
-* `--index INDEX, -i INDEX`: elasticsearch index name. Default is
+* `--index INDEX, -i INDEX`: Elasticsearch index name. Default is
   `content`. You can also set the `SHEER_ELASTICSEARCH_INDEX`
   environment variable.
 
 The `sheer` command also takes one of two positional arguments:
 
-* `index`: load content into Elasticsearch
-* `serve`: Serve content from elasticsearch using configuration and
-  templates at location
+* `index`: Load content into Elasticsearch.
+* `serve`: Serve content from Elasticsearch using configuration and
+  templates at location.
 
 These are covered in more detail below.
 
@@ -170,9 +170,9 @@ Sheer indexing allows configurable loading of content into  [Elasticsearch](http
 
 `sheer index` takes the following arguments:
 
-* `--reindex, -r`: recreate the index and reindex all content
+* `--reindex, -r`: Recreate the index and reindex all content.
 * `--processors [PROCESSORS [PROCESSORS ...]], -p [PROCESSORS
-  [PROCESSORS ...]]`: content processors to index
+  [PROCESSORS ...]]`: Content processors to index.
 
 These are covered in more detail below.
 
@@ -343,8 +343,8 @@ Sheer can serve the content it indexes in Elasticsearch via command-line in the 
 
 `sheer serve` takes the following arguments:
 
-* `--port PORT, -p PORT`: port to run the web server on
-* `--addr ADDR, -a ADDR`: address to run the web server on
+* `--port PORT, -p PORT`: Port to run the web server on.
+* `--addr ADDR, -a ADDR`: Address to run the web server on.
 
 Sheer does not serve any paths beginning with an underscore. They are considered private.
 

--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ Returns a JSON-compatible (but *not* JSON-encoded) dictionary of a query hit.
 Public Domain/CC0 1.0
 
 1. [Terms](TERMS.md)
-2. [License](COPYING.txt)
+2. [License](LICENSE)
 3. [CFPB Source Code Policy](https://github.com/cfpb/source-code-policy/)
 
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Running tests requires:
 
 ## Installation
 
+### Elasticsearch
+
 To install Sheer you will first need to install 
 [Elasticsearch](http://www.elasticsearch.org/). This can be acomplished 
 a number of ways, many of which are detailed in 
@@ -63,6 +65,19 @@ brew install elasticsearch
 ```
 
 There are also [Elasticsearch apt and Yum repositories](http://www.elastic.co/guide/en/elasticsearch/reference/current/setup-repositories.html).
+
+Before running Sheer, you will also need to ensure that Elasticsearch is
+running. When installing Elasticsearch on Mac OS X installed via
+Homebrew, Homebrew will provide some guidance like:
+
+```shell
+To have launchd start elasticsearch at login:
+    ln -sfv <homebrew location>/elasticsearch/*.plist ~/Library/LaunchAgents
+Then to load elasticsearch now:
+    launchctl load ~/Library/LaunchAgents/homebrew.mxcl.elasticsearch.plist
+```
+
+### Sheer
 
 To install Sheer itself, it is recommended to create a 
 [`virtualenv`](https://virtualenv.pypa.io/en/latest/) using 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ If you're not familiar with Elasticsearch, it is highly recommended that you rea
 
 * [Requirements](#requirements)
 * [Installation](#installation)
+* [Testing](#testing)
 * [Quick Start](#quick-start)
+* [General Usage](#general-usage)
 * [Indexing](#indexing)
     * [Reindexing](#reindexing)
     * [Partial Indexing](#partial-indexing)
@@ -86,6 +88,25 @@ installed again.
 
 ```shell
 pip install -e sheer
+```
+
+## Testing
+
+To run the Sheer tests, you'll need the Python packages 
+[nose](https://nose.readthedocs.org/en/latest/) and 
+[mock](http://www.voidspace.org.uk/python/mock/) installed. Both can be
+installed via `pip`:
+
+```shell
+pip install nose mock
+```
+
+Both are also installed by the Sheer [`requirements.txt` file](#installation).
+
+To run the tests, simply run:
+
+```shell
+nosetest sheer
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -1,122 +1,573 @@
-Sheer
-===================
+# Sheer
 
-Sheer provides:
+Sheer is a tool for [loading arbitrary content](#indexing) into [Elasticsearch](http://www.elasticsearch.org) and [serving that content](#serving) on the web using [Jinja2 templates](http://jinja.pocoo.org/). 
 
-- Tools for loading arbitrary content into elasticsearch
-- A WSGI server for mixing that content with Jinja2 templates 
+If you're not familiar with Elasticsearch, it is highly recommended that you read the Elasticsearch Definitive Guide's [Finding Your Feet](http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/_finding_your_feet.html).
 
-Additionally, we hope to provide
-- scripts for pre-generating HTML from said configuration and elasticsearch data.
-- A full-featured REST API
-- Tools for building elasticsearch "mappings" for your data
+* [Requirements](#requirements)
+* [Installation](#installation)
+* [Quick Start](#quick-start)
+* [Indexing](#indexing)
+    * [Reindexing](#reindexing)
+    * [Partial Indexing](#partial-indexing)
+	* [Sheer Index Settings](#sheer-index-settings)
+	* [Content Processors](#content-processors)
+	* [Mappings](#mappings)
+* [Serving](#serving)
+	* [Templates](#templates)
+		* [Context](#context)
+			* [`selected_filters_for_field`](#selected_filters_for_fieldfieldname)
+			* [`is_filter_selected`](#is_filter_selectedfieldname-value)
+			* [`queries`](#queries)
+			* [`more_like_this`](#more_like_thishit)
+			* [`get_document`](#get_documentdoctype-docid)
+	* [Elasticsearch Lookup URLs](#elasticsearch-lookup-urls)
+	* [Blueprints](#blueprints)
+	* [Query API](#query-api)
+		* [`QueryFinder`](#queryfinder)
+		* [`Query`](#query)
+		* [`QueryResult`](#queryresult)
+		* [`QueryHit`](#queryhit)
+- [Licensing](#licensing)
 
-The best place to start is with a demo site. Here's one:
-https://github.com/rosskarchner/itspecialists
 
-Sheer is a Python/Flask application. It requires Elastic Search.
+## Requirements
 
-Why Sheer? Why not Jekyll?
----------
+Sheer is a Python application that requires:
 
-Jekyll is pretty darn compelling, for a number of reasons:
+- [Elasticsearch](http://www.elasticsearch.org/)
+- [Flask](http://flask.pocoo.org/)
 
-- Ease of management
-- Ease of breaking out of the CMS (the "snowfall" problem)
-- Serving static files is fast
-- Bring your own version control
-- On the whole, less mysterious than CMS's.
+Recommended for installing and running Sheer:
 
-We want those advantages, but we don't want to have to anticipate every way our editorial team might wish to slice and serve content. 
-We don't want to have to anticipate what developers will want to do with our API, or which content third party publishers will want to syndicate on their site
-, or which collection of content people will want to subscribe to with RSS. 
-We want to pre-generate (Jekyll-style) the common pages, without precluding the stuff we haven't thought of yet.
+- [virtualenv](https://virtualenv.pypa.io/en/latest/)
+- [virtualenvwrapper](https://virtualenvwrapper.readthedocs.org)
 
-Our hypothesis is that we can combine some of Jekyll's ideas with a full-featured search engine, and get something powerful, flexible, productive, and fun.
+Running tests requires:
 
-Installation
-------------
+- [nose](https://nose.readthedocs.org/en/latest/)
 
-To get started with Sheer:
+## Installation
 
-Install [Elasticsearch](http://www.elasticsearch.org/) however you'd like. (We use [homebrew](http://brew.sh/).):
+To install Sheer you will first need to install 
+[Elasticsearch](http://www.elasticsearch.org/). This can be acomplished 
+a number of ways. On Mac OS X it can be installed using 
+[homebrew](http://brew.sh/):
 
 ```
 $ brew install elasticsearch
 ```
 
-Check out the sheer GitHub project (you may want to first navigate to your project directory, or wherever you work on code):
-```
-$ git clone https://github.com/cfpb/sheer.git
-```
+To install Sheer itself, it is recommended to create a 
+[`virtualenv`](https://virtualenv.pypa.io/en/latest/) using 
+[`virtualenvwrapper`](https://virtualenvwrapper.readthedocs.org).
 
-Create a virtualenv for sheer:
 ```
 $ mkvirtualenv sheer
+$ workon sheer
 ```
 
-The new virtualenv will activate right away. To activate it later on (say, in a new terminal session) use the command `workon sheer`.
+Then you can clone the Sheer repository and install the Python 
+requirements using `pip`:
 
-Install sheer into the virtualenv with the `-e` flag (which allows you to make changes to sheer itself). The path to sheer is the root directory of the GitHub repository you checked out (cloned) earlier, which likely will be `./sheer`:
-
-```
-$ pip install -e ~/path/to/sheer
-```
-
-Install sheer's python requirements:
-
-```
-$ pip install -r ~/path/to/sheer/requirements.txt
+```shell
+$ git clone https://github.com/cfpb/sheer
+$ pip install -r sheer/requirements.txt
 ```
 
-You should now be able to run the sheer command:
+You can then install Sheer with `pip`. `pip -e` installs Sheer in
+"editable" mode, which means it runs from the path where you've cloned
+it, and any changes you `git pull` from upstream won't have to be
+installed again.
+
+```shell
+$ pip install -e sheer
 ```
-$ sheer
 
-usage: sheer [-h] [--debug] {inspect,index,serve} …
-sheer: error: too few arguments
+## Quick Start
+
+This quick start assumes you have an existing Sheer site you want to
+load content for and serve.
+
+```shell
+$ cd path/to/my/sheer/site
 ```
 
-Status
-------------
+Index the site's content in Elasticsearch:
 
-Parts of it work!
-
-sheer index -l *directory* will pull a sites content into Elasticsearch
-
-sheer serve -l *directory* launches the web server
-
-With both commands, you can ommit the -l option to act on the current directory.
-
-Usage
---------------
-
+```shell
+$ sheer index
 ```
-sheer --help
-usage: sheer [-h] [--debug] [--location LOCATION]
-             [--elasticsearch ELASTICSEARCH] [--index INDEX]
-             {index,serve} ...
 
-document loader and dev server for Sheer, a content publishing system
+Serve the site at [http://localhost:7000](http://localhost:7000):
 
-positional arguments:
-  {index,serve}
-    index               load content into Elasticsearch
-    serve               serve content from elasticsearch, using configuration
-                        and templates at location
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --debug               print debugging output to the console
-  --location LOCATION, -l LOCATION
-                        Directory you want to operate on. You can also set the
-                        SHEER_LOCATION environment variable.
-  --elasticsearch ELASTICSEARCH, -e ELASTICSEARCH
-                        elasticsearch host:port pairs. Seperate hosts with
-                        commas. Default is localhost:9200. You can also set
-                        the SHEER_ELASTICSEARCH_HOSTS environment variable.
-  --index INDEX, -i INDEX
-                        elasticsearch index name. Default is 'content'. You
-                        can also set the SHEER_ELASTICSEARCH_INDEX environment
-                        variable.
+```shell
+$ sheer serve
 ```
+
+The site can also be served in "debug" mode:
+
+```shell
+$ sheer serve --debug
+```
+
+## General Usage
+
+The `sheer` command takes the following general arguments:
+
+* `-h`: show help message and exit
+* `--debug`: print debugging output to the console
+* `--location`: the directory you want to operate on. You can also set
+  the `SHEER_LOCATION` environment variable
+* `--elasticsearch ELASTICSEARCH, -e ELASTICSEARCH`: elasticsearch
+  host:port pairs. Seperate hosts with commas. Default is
+  `localhost:9200` You can also set the `SHEER_ELASTICSEARCH_HOSTS`
+  environment variable.
+* `--index INDEX, -i INDEX`: elasticsearch index name. Default is
+  `content`. You can also set the `SHEER_ELASTICSEARCH_INDEX`
+  environment variable.
+
+The `sheer` command also takes one of two positional arguments:
+
+* `index`: load content into Elasticsearch
+* `serve`: Serve content from elasticsearch using configuration and
+  templates at location
+
+These are covered in more detail below.
+
+## Indexing 
+
+```shell
+$ sheer index
+```
+
+Sheer indexing allows configurable loading of content into  [Elasticsearch](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-index_.html).
+
+`sheer index` takes the following arguments:
+
+* `--reindex, -r`: recreate the index and reindex all content
+* `--processors [PROCESSORS [PROCESSORS ...]], -p [PROCESSORS
+  [PROCESSORS ...]]`: content processors to index
+
+These are covered in more detail below.
+
+
+Sheer *does not index*:
+
+* `_settings/` 
+* `_layouts/` 
+* `_queries/` 
+* `_defaults/` 
+* `_lib/`
+* `_tests/`
+
+These are hard-coded in `indexer.py`.
+
+The basic indexing process:
+
+1. Creates the index with the given [settings](#sheer-index-settings) if it does not exist
+2. Creates the [mappings](#mappings) for each [content processor](#content-processors) if they do not exist
+3. Enumerates the documents to be loaded into Elasticsearch that are yeilded by the [content processor's `documents()` function](#content-processors). If the documents already exist they are updated.
+
+### Reindexing
+
+```shell
+$ sheer index --reindex
+```
+
+Destroys the index in Elasticsearch and recreates it, recreating the mappings and reloading all documents.
+
+### Partial Indexing
+
+```shell
+$ sheer index --processors posts
+```
+
+Reindex only content provided by the given [content processors](#content-processors). The documents provided by the given processor will be updated in Elasticsearch.
+
+```shell
+$ sheer index --processors posts --reindex
+```
+
+This will destroy the [mappings](#mappings) for the given [content processor](#content-processors) and recreate them, then load the documents provided by the given processor into Elasticsearch.
+
+### Sheer Index Settings
+
+Sheer reads settings from `_settings/settings.json`. These settings are passed as a document containing index settings to [`Elasticsearch.create`](https://elasticsearch-py.readthedocs.org/en/master/api.html#elasticsearch.Elasticsearch.create). Existing Sheer sites use this file to configure [Elasticsearch analyzers](http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/analysis-intro.html). 
+
+Analyzers tokenize both document fields during indexing and query strings for searching, that way there is consistency between terms being searched for and terms indexed.
+
+For example:
+
+```json
+{
+    "settings" : {
+        "analysis" : {
+            "analyzer" : {
+                "my_edge_ngram_analyzer" : {
+                    "tokenizer" : "my_edge_ngram_tokenizer"
+                }
+            },
+            "tokenizer" : {
+                "my_edge_ngram_tokenizer" : {
+                    "type" : "edgeNGram",
+                    "min_gram" : "2",
+                    "max_gram" : "5",
+                    "token_chars": [ "letter", "digit" ]
+                }
+            }
+        }
+    }
+}
+```
+
+This will use Elasticsearch's `edgeNGram` tokenizer (which only keeps n-grams, a sequence of text characters, from the beginning of a token) to build an analyzer
+
+See [Elasticsearch's Configuring Analyzers](http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/configuring-analyzers.html) for more information about configuration.
+
+
+### Content Processors
+
+Sheer reads Content Processors from `_settings/processors.json`. 
+
+Content Processors are configured with a unique name and a JSON object including at least the following fields:
+
+* `processor`: The name of a Python module within the Sheer site's `_lib` directory.
+* `mappings` (*optional*): The mappings file (within the Sheer site directory) for this content.
+
+The `processor` module must provide a `documents` [generator](https://wiki.python.org/moin/Generators) which takes the processor's `name` and the remaining keyword arguments from the JSON object and yields documents suitable for indexing in Elasticsearch. 
+
+```python
+def documents(name, **kwargs):
+	...
+		yield document
+```
+
+For example, a content processor might be configured like this in `processors.json`:
+
+```json
+{
+  "posts": {
+    "url": "$WORDPRESS/api/get_posts/",
+    "processor": "wordpress_post_processor",
+    "mappings": "_settings/posts_mappings.json"
+  }
+}
+```
+
+And may have the following corresponding `_lib/wordpress_post_processor.py`:
+
+```python
+def posts_at_url(url):
+	"""
+	Yield WordPress posts from the given URL
+	"""
+	...
+	
+def process_post(post):
+	"""
+	Process a post for indexing in Elasticsearch
+	"""
+	...
+
+def documents(name, url, **kwargs):
+	"""
+	Yield a document for indexing in Elasticsearch
+	"""
+    for post in posts_at_url(url):
+        yield process_post(post)
+```
+
+### Mappings
+
+Mappings are described in great detail in the [Elasticsearch mappings documentation](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping.html). Mapping defines the searchable characteristics of a document, such as which fields are searchable and how they're tokenized.
+
+Each [content processor](#content-processor) provides a mappings file path relative to the Sheer site directory. This file contains the `properties` JSON object for the mapping (as described in Elasticsearch's [PUT mapping API reference](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-put-mapping.html)). This is passed directly to Elasticsearch.
+
+For example: 
+
+```json
+{ "properties" :
+  {
+    "title" : {"type" : "string", "store" : "yes"},
+    "text" : {"type" : "string", "store" : "yes"},
+    "date" : {"type" : "date", "store": "yes"},
+    "category" : {"type":"string", "index": "not_analyzed"},
+    "author" : {"type":"string", "index":"not_analyzed"},
+    "tags" : {"type":"string", "store": "yes", "index":"not_analyzed"},
+    "excerpt" : {"type":"string", "store": "yes"},
+    "custom_fields": {
+            "properties": {
+                "display_in_newsroom": {"type":"string", "index":"not_analyzed"}
+            }
+    }
+  }
+}
+```
+
+A default `_settings/mappings.json`, if it exists, is also passed to Elasticsearch.
+
+
+## Serving
+
+```shell
+$ sheer serve
+```
+
+Sheer can serve the content it indexes in Elasticsearch via command-line in the foreground or via WSGI. Sheer serves its content using a [Flask](http://flask.pocoo.org/) application. 
+
+`sheer serve` takes the following arguments:
+
+* `--port PORT, -p PORT`: port to run the web server on
+* `--addr ADDR, -a ADDR`: address to run the web server on
+
+Sheer does not serve any paths beginning with an underscore. They are considered private.
+
+Sheer will serve the following content in order:
+
+1. `index.html` template from a directory containing it
+2. An Elasticsearch document from a [lookup URL](#elasticsearch-lookup-urls) 
+3. A [Flask Blueprint](#blueprints)
+
+## Templates
+
+Sheer will serve the `index.html` template from any directory under the site root not beginning with an underscore. So, given a `<site root>/blog/index.html`, Sheer will serve the template at `/blog/` and `/blog/index.html`. Sheer will also redirect `/blog` to `/blog/`.
+
+Sheer always adds two search paths beyond the request directory for [Jinja2 templates](http://jinja.pocoo.org/):
+
+* `_layouts`
+* `_includes`
+
+There are no specific rules within Sheer that dictate what templates go in either location, but they provide for some logical separation. These search paths include parent directories up to the root of the site.
+
+### Context
+
+Sheer provides convenient access to  query tools for use in templates using the following context variables:
+
+#### `selected_filters_for_field(fieldname)`
+
+Returns the selected filter values contained in the request query string for a given `fieldname`.
+
+#### `is_filter_selected(fieldname, value)`
+
+Returns whether or not the given filter `value` is selected in the request query string for the given `fieldname`. 
+
+#### `queries`
+
+A [`QueryFinder`](#queryfinder) object for lookup of pre-defined Elasticsearch queries stored as JSON files in `<site_root>/_queries/<query_name>.json`. This context variable exposes the Sheer [query API](#query-api) to templates.
+
+For example, within a [Jinja2 template](http://jinja.pocoo.org/), one might do the following:
+
+```jinja
+{% set query = queries.posts %}
+{% set posts = query.search_with_url_arguments(size=10) %}
+{%- for post in posts %}
+	...
+{% endfor %}
+```
+
+#### `more_like_this(hit)`
+
+Performs an [Elasticsearch "more like this" (mlt)](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-more-like-this.html) search for documents that are "like" the document described by the given [`QueryHit`](#queryhit) object. 
+
+Returns a [`QueryResult`](#queryresult) object. 
+
+Optionally takes additional keyword arguments corrosponding to the "mlt" parameters [described in the Elasticsearch documentation](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-more-like-this.html).
+
+```jinja
+{% set query = queries.posts %}
+{% set posts = query.search_with_url_arguments(size=10) %}
+{%- for post in posts %}
+	...
+    {% for similar in more_like_this(post) %}
+    	...
+	{% endfor %}
+	...
+{% endfor %}
+```
+
+#### `get_document(doctype, docid)`
+
+Performs an [Elasticsearch "get"](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-get.html) for a document of the given `doctype` with the given `docid`. Returns a single [`QueryHit`](#queryhit) object.
+
+## Elasticsearch Lookup URLS
+
+Lookup URLs in Sheer are URLs at which Elasticsearch lookups will be performed. Lookup URLs are defined in `_settings/lookups.json`. For example:
+
+```json
+{
+  "post": {
+    "url":       "/blog/<id>/",
+    "type":      "posts",
+    "permalink": true
+  },
+}
+```
+
+This will add a URL pattern where the `<id>` in the URL pattern is the Elasticsearch id of a document of the given `type`. These documents are then templated using either an `index.html` file at their full path (include `<id>`) or the first `_single.html` template that is found in the search path.
+
+In this case, documents in Elasticsearch with the type `posts` will be served at the URL `/blog/<id>` and templated with either:
+
+1. `<site root>/blog/<id>/index.html`
+2. `<site root>/blog/_single.html`
+3. `<site root>/_single.html`.
+
+
+## Blueprints
+
+Sheer locals Flask Blueprints from `_settings/blueprints.json`. This a JSON file that includes the Python `package` which contains each blueprint, and the blueprint itself as `module`. 
+
+For example, the following blueprint:
+
+```pyhton
+myblueprint = Blueprint("myblueprint", __name__, url_prefix="")
+```
+
+Defined in the Python package and module `ablueprint.controllers` would be configured like this:
+
+```json
+{
+  "myblueprint": {
+    "package": "ablueprint.controllers",
+    "module":  "myblueprint"
+  }
+}
+```
+
+## Query API
+
+Sheer includes some wrappers around Elasticsearch queries that allow for queries to be pre-defined in JSON files in `<site_root>/_queries/<query_name>.json`, run, and results of those queries to be easily accessed. 
+
+#### `QueryFinder`
+
+`QueryFinder` provides a simple attribute-lookup of [Elasticsearch JSON queries](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html) defined in `<site_root>/_queries/<query_name>.json` and will return a [`Query`](#query) object.  
+
+For example, given the following query defined in `<site root>/_queries/posts.json`:
+
+```json
+{
+  "name": "Blog Posts",
+  "query": {
+    "doc_type": "posts",
+    "size": 10,
+    "sort": "date:desc"
+  }
+}
+```
+
+From within the Sheer Flask application:
+
+```python
+>>> queries = QueryFinder()
+>>> posts_query = queries.posts
+```
+
+A [`Query`](#query) object for the archive query is available at `queries.posts`. 
+
+File lookups are done on the fly and a new `Query` instance is created every time the `posts` attribute is accessed. 
+
+#### `Query`
+
+`Query` wraps an [Elasticsearch search](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-search.html) fetched via [`QueryFinder`](#queryfinder).
+
+```python
+>>> queries = QueryFinder()
+>>> posts_query = queries.posts
+>>> posts_results = queries.posts.search_with_url_arguments(size=10)
+```
+
+##### `search_with_url_arguments(aggregations=None, **kwargs)`
+
+Perform the search with the given keyword arguments, returning a [`QueryResult`](#queryresult) object.
+
+Keyword arguments should be [Elasticsearch request body parameters](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html)
+
+If `aggregations` are given, an [Elasticsearch terms aggregation](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html) is used to return counts and possible values for the given fields.
+
+##### `possible_values_for(field, **kwargs)`
+
+Return possible values for the field. This performs a search using [Elasticsearch terms aggregation](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html). Keyword arguments are [Elasticsearch request body parameters](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html). 
+
+For example, `possible_values_for('category', doc_type='posts')` would return the counts and existing values of the field `category` on all `posts` documents.
+
+#### `QueryResult`
+
+`QueryResult` objects wrap [Elasticsearch search results](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/_the_search_api.html). `QueryResult` objects are [iterables](https://docs.python.org/2/glossary.html#term-iterable) that yield   [`QueryHit`](#queryhit) objects for each result.
+
+```python
+>>> queries = QueryFinder()
+>>> posts_query = queries.posts
+>>> posts_results = queries.posts.search_with_url_arguments(size=10)
+>>> for result_hit in post_results:
+>>>		...
+```
+
+`QueryResult` objects provide several properties to aid in pagination of results:
+
+* `total`: the total number of results
+* `size`: the number of results included in this query
+* `from_`: the number of results skipped in this query
+* `pages`: the total number of pages given the above `size`
+* `current_page`: the current page given the above `size` and `from_` values
+
+##### `aggregations(fieldname)`
+
+Returns the [terms aggregation](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html) dictionary that resulted from the query for the given `fieldname`.
+
+##### `json_compatible()`
+
+Returns a JSON-compatible (but *not* JSON-encoded) dictionary of the query results, including the above properties and the resulting hits.
+
+##### `url_for_page(pagenum)`
+
+Returns a URL for the given page number within the query.
+
+#### `QueryHit`
+
+A `QueryHit` object is the result of an Elasticsearch query. `QueryHit` objects provide the query result's fields as attributes. Given the following blog post document stored in Elasticsearch:
+
+```json
+{  
+    "id": 12345,
+    "title": "An Example Blog Post",
+    "date": "2015-01-11T09:34:40Z",
+    "slug": "an-example-blog-post",
+    "author": [  
+        "Hugh Man"
+    ],
+    "content": "...",
+    "excerpt": "...",
+    "category": [  
+        "Announcements"
+    ]
+}
+```
+
+Each of the JSON object's properties would be accessible as a `QueryHit` object's attributes:
+
+```python
+>>> queries = QueryFinder()
+>>> posts_query = queries.posts
+>>> posts_results = queries.posts.search_with_url_arguments(size=10)
+>>> for result_hit in post_results:
+>>>		print result_hit.title, result_hit.author
+```
+
+##### `permalink()`
+
+Returns the permanent link to this Elasticsearch document *if* the type of this query hit (for our blog example, "posts") corropsonds to one of the [lookup URLs](#elasticsearch-lookup-urls) configured in a Sheer site.
+
+##### `json_compatible()`
+
+Returns a JSON-compatible (but *not* JSON-encoded) dictionary of a query hit.
+
+
+## Licensing 
+
+Public Domain/CC0 1.0
+
+1. [Terms](TERMS.md)
+2. [License](COPYING.txt)
+3. [CFPB Source Code Policy](https://github.com/cfpb/source-code-policy/)
+
+

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To install Sheer you will first need to install
 [Elasticsearch](http://www.elasticsearch.org/). This can be acomplished 
 a number of ways, many of which are detailed in 
 [in the Elasticsearch documentation](http://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html). 
-On Mac OS X it can be installed using [homebrew](http://brew.sh/):
+On Mac OS X it can be installed using [Homebrew](http://brew.sh/):
 
 ```
 brew install elasticsearch

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ If you're not familiar with Elasticsearch, it is highly recommended that you rea
 
 * [Requirements](#requirements)
 * [Installation](#installation)
+* [General Usage](#general-usage)
 * [Testing](#testing)
 * [Quick Start](#quick-start)
-* [General Usage](#general-usage)
 * [Indexing](#indexing)
     * [Reindexing](#reindexing)
     * [Partial Indexing](#partial-indexing)
@@ -90,6 +90,30 @@ installed again.
 pip install -e sheer
 ```
 
+## General Usage
+
+The `sheer` command takes the following general arguments:
+
+* `-h`: Show help message and exit.
+* `--debug`: Print debugging output to the console.
+* `--location`: The directory you want to operate on. You can also set
+  the `SHEER_LOCATION` environment variable.
+* `--elasticsearch ELASTICSEARCH, -e ELASTICSEARCH`: Elasticsearch
+  host:port pairs. Seperate hosts with commas. Default is
+  `localhost:9200` You can also set the `SHEER_ELASTICSEARCH_HOSTS`
+  environment variable.
+* `--index INDEX, -i INDEX`: Elasticsearch index name. Default is
+  `content`. You can also set the `SHEER_ELASTICSEARCH_INDEX`
+  environment variable.
+
+The `sheer` command also takes one of two positional arguments:
+
+* `index`: Load content into Elasticsearch.
+* `serve`: Serve content from Elasticsearch using configuration and
+  templates at location.
+
+These are covered in more detail below.
+
 ## Testing
 
 To run the Sheer tests, you'll need the Python packages 
@@ -135,30 +159,6 @@ The site can also be served in "debug" mode:
 ```shell
 sheer serve --debug
 ```
-
-## General Usage
-
-The `sheer` command takes the following general arguments:
-
-* `-h`: Show help message and exit.
-* `--debug`: Print debugging output to the console.
-* `--location`: The directory you want to operate on. You can also set
-  the `SHEER_LOCATION` environment variable.
-* `--elasticsearch ELASTICSEARCH, -e ELASTICSEARCH`: Elasticsearch
-  host:port pairs. Seperate hosts with commas. Default is
-  `localhost:9200` You can also set the `SHEER_ELASTICSEARCH_HOSTS`
-  environment variable.
-* `--index INDEX, -i INDEX`: Elasticsearch index name. Default is
-  `content`. You can also set the `SHEER_ELASTICSEARCH_INDEX`
-  environment variable.
-
-The `sheer` command also takes one of two positional arguments:
-
-* `index`: Load content into Elasticsearch.
-* `serve`: Serve content from Elasticsearch using configuration and
-  templates at location.
-
-These are covered in more detail below.
 
 ## Indexing 
 

--- a/README.md
+++ b/README.md
@@ -46,17 +46,21 @@ Recommended for installing and running Sheer:
 Running tests requires:
 
 - [nose](https://nose.readthedocs.org/en/latest/)
+- [mock](http://www.voidspace.org.uk/python/mock/)
 
 ## Installation
 
 To install Sheer you will first need to install 
 [Elasticsearch](http://www.elasticsearch.org/). This can be acomplished 
-a number of ways. On Mac OS X it can be installed using 
-[homebrew](http://brew.sh/):
+a number of ways, many of which are detailed in 
+[in the Elasticsearch documentation](http://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html). 
+On Mac OS X it can be installed using [homebrew](http://brew.sh/):
 
 ```
 $ brew install elasticsearch
 ```
+
+There are also [Elasticsearch apt and Yum repositories](http://www.elastic.co/guide/en/elasticsearch/reference/current/setup-repositories.html).
 
 To install Sheer itself, it is recommended to create a 
 [`virtualenv`](https://virtualenv.pypa.io/en/latest/) using 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ a number of ways, many of which are detailed in
 On Mac OS X it can be installed using [homebrew](http://brew.sh/):
 
 ```
-$ brew install elasticsearch
+brew install elasticsearch
 ```
 
 There are also [Elasticsearch apt and Yum repositories](http://www.elastic.co/guide/en/elasticsearch/reference/current/setup-repositories.html).
@@ -67,16 +67,16 @@ To install Sheer itself, it is recommended to create a
 [`virtualenvwrapper`](https://virtualenvwrapper.readthedocs.org).
 
 ```
-$ mkvirtualenv sheer
-$ workon sheer
+mkvirtualenv sheer
+workon sheer
 ```
 
 Then you can clone the Sheer repository and install the Python 
 requirements using `pip`:
 
 ```shell
-$ git clone https://github.com/cfpb/sheer
-$ pip install -r sheer/requirements.txt
+git clone https://github.com/cfpb/sheer
+pip install -r sheer/requirements.txt
 ```
 
 You can then install Sheer with `pip`. `pip -e` installs Sheer in
@@ -85,7 +85,7 @@ it, and any changes you `git pull` from upstream won't have to be
 installed again.
 
 ```shell
-$ pip install -e sheer
+pip install -e sheer
 ```
 
 ## Quick Start
@@ -94,25 +94,25 @@ This quick start assumes you have an existing Sheer site you want to
 load content for and serve.
 
 ```shell
-$ cd path/to/my/sheer/site
+cd path/to/my/sheer/site
 ```
 
 Index the site's content in Elasticsearch:
 
 ```shell
-$ sheer index
+sheer index
 ```
 
 Serve the site at [http://localhost:7000](http://localhost:7000):
 
 ```shell
-$ sheer serve
+sheer serve
 ```
 
 The site can also be served in "debug" mode:
 
 ```shell
-$ sheer serve --debug
+sheer serve --debug
 ```
 
 ## General Usage
@@ -142,7 +142,7 @@ These are covered in more detail below.
 ## Indexing 
 
 ```shell
-$ sheer index
+sheer index
 ```
 
 Sheer indexing allows configurable loading of content into  [Elasticsearch](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-index_.html).
@@ -176,7 +176,7 @@ The basic indexing process:
 ### Reindexing
 
 ```shell
-$ sheer index --reindex
+sheer index --reindex
 ```
 
 Destroys the index in Elasticsearch and recreates it, recreating the mappings and reloading all documents.
@@ -184,13 +184,13 @@ Destroys the index in Elasticsearch and recreates it, recreating the mappings an
 ### Partial Indexing
 
 ```shell
-$ sheer index --processors posts
+sheer index --processors posts
 ```
 
 Reindex only content provided by the given [content processors](#content-processors). The documents provided by the given processor will be updated in Elasticsearch.
 
 ```shell
-$ sheer index --processors posts --reindex
+sheer index --processors posts --reindex
 ```
 
 This will destroy the [mappings](#mappings) for the given [content processor](#content-processors) and recreate them, then load the documents provided by the given processor into Elasticsearch.
@@ -315,7 +315,7 @@ A default `_settings/mappings.json`, if it exists, is also passed to Elasticsear
 ## Serving
 
 ```shell
-$ sheer serve
+sheer serve
 ```
 
 Sheer can serve the content it indexes in Elasticsearch via command-line in the foreground or via WSGI. Sheer serves its content using a [Flask](http://flask.pocoo.org/) application. 

--- a/sheer/scripts/sheer
+++ b/sheer/scripts/sheer
@@ -19,33 +19,33 @@ DEBUG = bool(os.environ.get('SHEER_DEBUG', False))
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(prog='sheer',
-                                     description="document loader and dev server for Sheer, a content publishing system")
+                                     description="document loader and dev server for Sheer, a content publishing system.")
 
     subparsers = parser.add_subparsers()
 
     index_parser = subparsers.add_parser('index',
-                                         help='load content into Elasticsearch')
+                                         help='Load content into Elasticsearch.')
     index_parser.add_argument('--reindex', '-r', action="store_true",
-                              help="recreate the index and reindex all content")
+                              help="Recreate the index and reindex all content.")
     index_parser.add_argument('--processors', '-p', nargs='*',
-                              help='content processors to index')
+                              help='Content processors to index.')
     index_parser.set_defaults(func=sheer.indexer.index_location)
 
-    server_parser=subparsers.add_parser('serve', help= "serve content from elasticsearch, using configuration and templates at location")
+    server_parser=subparsers.add_parser('serve', help= "Serve content from Elasticsearch, using configuration and templates at location.")
     server_parser.set_defaults(func=sheer.server.serve_wsgi_app_with_cli_args)
     server_parser.add_argument('--port', '-p',
-            default= '7000', help="port to run the web server on")
+            default= '7000', help="Port to run the web server on.")
     server_parser.add_argument('--addr', '-a',
-            default= '0.0.0.0', help="address to run the web server on")
+            default= '0.0.0.0', help="Address to run the web server on.")
 
-    build_parser=subparsers.add_parser('build', help='generate a static version of this site')
+    build_parser=subparsers.add_parser('build', help='Generate a static version of this site.')
     build_parser.set_defaults(func=sheer.builder.build_with_cli_args)
 
     for p in [parser, index_parser, server_parser]:
-        p.add_argument('--debug', help="print debugging output to the console", action='store_true', default=DEBUG)
+        p.add_argument('--debug', help="Print debugging output to the console.", action='store_true', default=DEBUG)
         p.add_argument('--location', '-l', default=LOCATION, help="Directory you want to operate on. You can also set the SHEER_LOCATION environment variable.")
-        p.add_argument('--elasticsearch', '-e', default=ELASTICSEARCH_HOSTS, help="elasticsearch host:port pairs. Separate hosts with commas. Default is localhost:9200. You can also set the SHEER_ELASTICSEARCH_HOSTS environment variable.")
-        p.add_argument('--index', '-i', default=ELASTICSEARCH_INDEX, help="elasticsearch index name. Default is 'content'. You can also set the SHEER_ELASTICSEARCH_INDEX environment variable.")
+        p.add_argument('--elasticsearch', '-e', default=ELASTICSEARCH_HOSTS, help="Elasticsearch host:port pairs. Separate hosts with commas. Default is localhost:9200. You can also set the SHEER_ELASTICSEARCH_HOSTS environment variable.")
+        p.add_argument('--index', '-i', default=ELASTICSEARCH_INDEX, help="Elasticsearch index name. Default is 'content'. You can also set the SHEER_ELASTICSEARCH_INDEX environment variable.")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This PR is a significant overhaul of the Sheer README with the goal of making it clearer what Sheer does and can be used for, and how to use it (API documentation both for python developers and for front-ends). This includes a lot of the same information as the old README, but in some different places. 

It removes the section about Jekyll because, honestly, coming to Sheer for the first time that certainly confused me, because however Sheer might have begun life it's a very different beast from Jekyll right now. 

I've also provided some links to Elasticsearch documentation interspersed with the content, since Sheer uses Elasticsearch relatively transparently.

@dpford contributed to this while it was in the wiki. I welcome any other suggestions on how to make Sheer more understandable. It's not hard, it's just misunderstood.

You can view [the updated README in my fork](https://github.com/willbarton/sheer/blob/readme-update/README.md).

## Reviewers

@rosskarchner 
@dpford 
@kurtwall 
