### PR TITLE
Convert date to datetime object before passing into feed

### DIFF
--- a/sheer/feeds.py
+++ b/sheer/feeds.py
@@ -3,15 +3,17 @@ from flask import request
 from werkzeug.contrib.atom import AtomFeed
 import flask
 import os
+import dateutil.parser
 
 from .query import QueryFinder
 from .indexer import read_json_file
 
 PARAM_TOKEN = '$$'
-ALLOWED_FEED_PARAMS = ('feed_title')
+ALLOWED_FEED_PARAMS = ('feed_title', 'feed_url')
 ALLOWED_ENTRY_PARAMS = ('entry_url', 'entry_title', 'entry_content',
                         'entry_author', 'entry_updated', 'entry_content_type',
                         'entry_summary', 'entry_published', 'entry_rights')
+DATE_PARAMS = ('updated', 'published')
 
 
 def make_external(url):
@@ -32,27 +34,31 @@ class Feed(object):
     # Make sure only allowed feed params are passed into the feed
     def __init__(self, settings):
         self.feed_url = request.url
-        self.url = request.url_root
         for setting in settings:
             if setting.startswith('feed_') and setting in ALLOWED_FEED_PARAMS:
                 setting_trimmed = setting.replace('feed_', '')
                 setattr(self, setting_trimmed, settings[setting])
 
+        if self.url:
+            self.url = make_external(self.url)
 
 class Entry(object):
 
     # Make sure only allowed entry params are passed into the feed
     def __init__(self, item, settings):
         for setting in settings:
-            attribute = settings[setting].replace('$$', '')
+            attribute = settings[setting].replace(PARAM_TOKEN, '')
             if setting.startswith('entry_') and \
                 setting in ALLOWED_ENTRY_PARAMS and \
                     hasattr(item, attribute):
                 setting_trimmed = setting.replace('entry_', '')
-                setattr(self, setting_trimmed, getattr(item, attribute))
 
-        if self.url:
-            self.url = make_external(self.url)
+                # Dates must be in datetime.datetime format
+                if setting_trimmed in DATE_PARAMS:
+                    setattr(self, setting_trimmed, 
+                        dateutil.parser.parse(getattr(item, attribute)))
+                else:
+                    setattr(self, setting_trimmed, getattr(item, attribute))
 
 
 def add_feeds_to_sheer(app):


### PR DESCRIPTION
Werkzeug Atom feeds require date types to be in datetime.datetime format, so this makes that conversion when necessary.   This also fixes an issue where the URL for the main feed wasn't correct.

Review: @willbarton @kurtw

How to test:

1. Checkout [this](https://github.com/cfpb/cfgov-refresh/pull/437) PR
2. Navigate to /feed/posts/ and /feed/newsroom/