### PR TITLE
Minor Semantic correction to README: ES is needed to run, not install, Sheer

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Running tests requires:
 
 ### Elasticsearch
 
-To install Sheer you will first need to install 
+To run Sheer you will first need to install 
 [Elasticsearch](http://www.elasticsearch.org/). This can be acomplished 
 a number of ways, many of which are detailed in 
 [in the Elasticsearch documentation](http://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html). 


### PR DESCRIPTION
Of course I forgot to push this up to my Github fork yesterday after my other changes before #94 was merged. 

This just a minor semantic change: Elasticsearch is required to *run* Sheer, but not to *install* it.