### PR TITLE
Specified version for itsdangerous

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ WebOb==1.2.3
 Werkzeug==0.9.1
 autopep8==0.9.2
 elasticsearch==0.4.3
-itsdangerous
+itsdangerous>=0.24
 mock==1.0.1
 nose==1.3.0
 pep8==1.4.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ WebOb==1.2.3
 Werkzeug==0.9.1
 autopep8==0.9.2
 elasticsearch==0.4.3
-itsdangerous>=0.24
+itsdangerous==0.24
 mock==1.0.1
 nose==1.3.0
 pep8==1.4.6


### PR DESCRIPTION
After the pbr conversion, running `pip install -e . --upgrade` was breaking on certain environments without a version specified for itsdangerous.  This fixes that problem.