### PR TITLE
Remove default ES mapping functionality

### DIFF
--- a/sheer/test_indexing.py
+++ b/sheer/test_indexing.py
@@ -79,10 +79,6 @@ class TestIndexing(object):
         index_location(test_args, self.config)
 
         mock_es.indices.create.assert_called_with(index=self.config['index'])
-        mock_es.indices.put_mapping.assert_called_with(
-            index=self.config['index'],
-            doc_type='posts',
-            body={'posts': {}})
         mock_es.create.assert_called_with(
             index=self.config['index'],
             doc_type='posts',
@@ -125,10 +121,6 @@ class TestIndexing(object):
 
         mock_es.indices.delete.assert_called_with(self.config['index'])
         mock_es.indices.create.assert_called_with(index=self.config['index'])
-        mock_es.indices.put_mapping.assert_called_with(
-            index=self.config['index'],
-            doc_type='posts',
-            body={'posts': {}})
         mock_es.create.assert_called_with(
             index=self.config['index'],
             doc_type='posts',
@@ -214,11 +206,6 @@ class TestIndexing(object):
         mock_es.indices.delete_mapping.assert_called_with(
             index=self.config['index'],
             doc_type='posts')
-        mock_es.indices.put_mapping.assert_called_with(
-            index=self.config['index'],
-            doc_type='posts',
-            body={'posts': {}})
-
         mock_es.create.assert_called_with(
             index=self.config['index'],
             doc_type='posts',


### PR DESCRIPTION
Currently, when an Elasticsearch mapping isn't specified in the `processors.json` file, a default mapping is set (found in /_defaults/).  This might have made sense back when we had a single post type, but now that we have a number of different post types with varying fields, this seems wrong.  

We should still create an explicit mapping for each doc_type, but let Elasticsearch take its best guess at a mapping in the absence of a supplied one, rather than use an incorrect mapping not meant for that doc_type.

Review: @rosskarchner @Scotchester @willbarton 