### PR TITLE
Fix template search bug, change name of function, remove unnecessary lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ For example, within a [Jinja2 template](http://jinja.pocoo.org/), one might do t
 
 ```jinja
 {% set query = queries.posts %}
-{% set posts = query.search_with_url_arguments(size=10) %}
+{% set posts = query.search(size=10) %}
 {%- for post in posts %}
 	...
 {% endfor %}
@@ -416,7 +416,7 @@ Optionally takes additional keyword arguments corrosponding to the "mlt" paramet
 
 ```jinja
 {% set query = queries.posts %}
-{% set posts = query.search_with_url_arguments(size=10) %}
+{% set posts = query.search(size=10) %}
 {%- for post in posts %}
 	...
     {% for similar in more_like_this(post) %}
@@ -513,10 +513,10 @@ File lookups are done on the fly and a new `Query` instance is created every tim
 ```python
 >>> queries = QueryFinder()
 >>> posts_query = queries.posts
->>> posts_results = queries.posts.search_with_url_arguments(size=10)
+>>> posts_results = queries.posts.search(size=10)
 ```
 
-##### `search_with_url_arguments(aggregations=None, **kwargs)`
+##### `search(aggregations=None, **kwargs)`
 
 Perform the search with the given keyword arguments, returning a [`QueryResult`](#queryresult) object.
 
@@ -537,7 +537,7 @@ For example, `possible_values_for('category', doc_type='posts')` would return th
 ```python
 >>> queries = QueryFinder()
 >>> posts_query = queries.posts
->>> posts_results = queries.posts.search_with_url_arguments(size=10)
+>>> posts_results = queries.posts.search(size=10)
 >>> for result_hit in post_results:
 >>>		...
 ```
@@ -588,7 +588,7 @@ Each of the JSON object's properties would be accessible as a `QueryHit` object'
 ```python
 >>> queries = QueryFinder()
 >>> posts_query = queries.posts
->>> posts_results = queries.posts.search_with_url_arguments(size=10)
+>>> posts_results = queries.posts.search(size=10)
 >>> for result_hit in post_results:
 >>>		print result_hit.title, result_hit.author
 ```

--- a/sheer/apis/apiv1.py
+++ b/sheer/apis/apiv1.py
@@ -27,7 +27,7 @@ def add_to_sheer(app):
             query_finder = default_query_finder()
             query = getattr(query_finder, name) or flask.abort(404)
             request = flask.request
-            return query.search_with_url_arguments()
+            return query.search()
 
     api.add_resource(QueryResource, '/api/v1/q/<name>.json')
 

--- a/sheer/feeds.py
+++ b/sheer/feeds.py
@@ -70,7 +70,7 @@ def add_feeds_to_sheer(app):
         atom_feed = AtomFeed(**feed.__dict__)
         query_finder = QueryFinder()
         query = getattr(query_finder, name) or flask.abort(404)
-        items = query.search_with_url_arguments()
+        items = query.search()
 
         for item in items:
             entry = Entry(item, settings)


### PR DESCRIPTION
When searching using search_with_url_arguments from within a template, the function will take in url arguments, as well as arguments from the function. This adds a parameter to flag if that behavior is desired. The name of the function has also been changed, and needs to be updated in the repo's that use it: [cfgov-refresh](https://github.com/cfpb/cfgov-refresh), [owning-a-home](https://github.com/cfpb/owning-a-home/blob/master/src/process/_process-step.html)

@dpford @rosskarchner