### PR TITLE
Add timezone to dateformat function

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ mock==1.0.1
 nose==1.3.0
 pep8==1.4.6
 python-dateutil==2.1
+pytz==2015.4
 requests==1.2.3
 six==1.9.0
 urllib3==1.7.1

--- a/sheer/templates.py
+++ b/sheer/templates.py
@@ -1,11 +1,15 @@
 import datetime
 import flask
 from dateutil import parser
+from pytz import timezone
 
 
-def date_formatter(value, format="%Y-%m-%d"):
+def date_formatter(value, format="%Y-%m-%d", tz='America/New_York'):
     if type(value) not in [datetime.datetime, datetime.date]:
-        dt = parser.parse(value, default=datetime.date.today().replace(day=1))
+        date = parser.parse(value, default=datetime.datetime.today().replace(day=1))
+        naive = date.replace(tzinfo=None)
+        dt = timezone(tz).localize(naive)
+        print dt.tzinfo
     else:
         dt = value
 

--- a/sheer/wsgi.py
+++ b/sheer/wsgi.py
@@ -148,8 +148,8 @@ def app_with_config(config):
         return urlparse(url).netloc.replace('www.', '')
 
     @app.template_filter(name='date')
-    def date_filter(value, format="%Y-%m-%d"):
-        return date_formatter(value, format)
+    def date_filter(value, format="%Y-%m-%d", tz="America/New_York"):
+        return date_formatter(value, format, tz)
 
     @app.template_filter(name='markdown')
     def markdown_filter(raw_text):


### PR DESCRIPTION
### Attention
You must run a `pip install -r requirements.txt` to grab the pytz package this introduces as a dependency.

### Overview
Timezones are a pain. This makes it so you can pass the name of a timezone and it will be able to create a timestamp much like this `MAR 12, 2001 6:15 AM CST`

### Test
Pass in a ISO8601 timestamp and a timezone name to the `date()` filter in jinja2. If the output is like the example above then success!

@jimmynotjim @dpford @rosskarchner 