### PR TITLE
Add when function to the context

### DIFF
--- a/sheer/query.py
+++ b/sheer/query.py
@@ -308,12 +308,14 @@ def add_query_utilities(app):
 
     def convert_to_datetime(timestamp):
         date = parser.parse(timestamp)
+        if not date.tzinfo:
+            date = date.replace(tzinfo=timezone('America/New_York'))
         return date.astimezone(timezone('UTC'))
 
     def when(starttime, endtime):
         start = convert_to_datetime(starttime)
         end = convert_to_datetime(endtime)
-        if start > datetime.datetime.now(timezone('UTC')):
+        if start >= datetime.datetime.now(timezone('UTC')):
             return 'future'
         elif end <= datetime.datetime.now(timezone('UTC')):
             return 'past'

--- a/sheer/query.py
+++ b/sheer/query.py
@@ -311,8 +311,8 @@ def add_query_utilities(app):
         return date.astimezone(timezone('UTC'))
 
     def when(starttime, endtime):
-        start = convert_to_datetime(starttime['date'])
-        end = convert_to_datetime(endtime['date'])
+        start = convert_to_datetime(starttime)
+        end = convert_to_datetime(endtime)
         if start > datetime.datetime.now(timezone('UTC')):
             return 'future'
         elif end <= datetime.datetime.now(timezone('UTC')):


### PR DESCRIPTION
This adds a new function to the context called `when`. It takes two parameters: `starttime` and `endtime`. It is meant to figure out if the time period (between starttime and endtime) is in the past, present, or future. Actually, those are the strings it returns: `'past'/'present'/'future'`.

This requires the package pytz. You have to run `pip install -r requirements.txt` in order for this to work.

@dpford @rosskarchner 
